### PR TITLE
Add support for python 3.10, drop 3.6, fix dev requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,34 +7,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    name: Python ${{ matrix.python-version}}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.3.5
 
-      - name: Set up Python 3.6
-        # actions/setup-python@v1.1.1
+      - name: Set up Python
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.7
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.8
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.9
-
-      - name: Install CI dependencies
+      - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install '.[dev]'
 
-      - name: Run tests
+      - name: Lint
+        run: make lint
+
+      - name: Test
         run: tox

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DEFAULT_GOAL := help
 PROJECT=crashstats_tools
-BLACKVERSION=py36
+BLACKVERSION=py37
 
 .PHONY: help
 help:
@@ -19,5 +19,14 @@ lint:  ## Lint and black reformat files
 	black --target-version=${BLACKVERSION} ${PROJECT} tests setup.py
 	flake8 ${PROJECT} tests
 
+.PHONY: test
 test:  ## Run tests
 	tox
+
+.PHONY: checkrot
+checkrot:  ## Check package rot for dev dependencies
+	python -m venv ./tmpvenv/
+	./tmpvenv/bin/pip install -U pip
+	./tmpvenv/bin/pip install '.[dev]'
+	./tmpvenv/bin/pip list -o
+	rm -rf ./tmpvenv/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
--e .
-
-black==19.10b0
-check-manifest==0.42
-flake8==3.8.1
-pytest==5.4.2
-tox==3.15.1
-twine==3.1.1
-wheel==0.34.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,20 @@ def get_version():
     return re.search(vsre, version_file, re.M).group(1)
 
 
-install_requires = ["click", "requests", "more_itertools"]
+INSTALL_REQUIRES = ["click", "requests", "more_itertools"]
+
+EXTRAS_REQUIRE = {
+    "dev": [
+        "black==19.10b0",
+        "check-manifest==0.47",
+        "flake8==4.0.1",
+        "pytest==6.2.5",
+        "tox==3.24.4",
+        "tox-gh-actions==2.8.1",
+        "twine==3.4.2",
+        "wheel==0.37.0",
+    ]
+}
 
 
 setup(
@@ -36,8 +49,9 @@ setup(
     license="Mozilla Public License v2",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=install_requires,
-    python_requires=">=3.6",
+    install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
+    python_requires=">=3.7",
     entry_points="""
         [console_scripts]
         fetch-data=crashstats_tools.cmd_fetch_data:fetch_data
@@ -49,10 +63,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,17 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py37,py38,py39,py310
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
+install_command = pip install {packages}
+extras = dev
 commands = 
-    pip install -r requirements-dev.txt
     flake8
     black --check
     pytest


### PR DESCRIPTION
This adds support for Python 3.10 by adding it to the tox.ini.

This drops support for Python 3.6.

This fixes CI to run a matrix strategy so it's doing the tests per
Python version in parallel.

This fixes dev requirements so they're defined in `setup.py` rather than
a separate `requirements-dev.txt` file.

Fixes #40 